### PR TITLE
Bump server version

### DIFF
--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: "2.20.0.0"
+version: "2.21.0.0"
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
The most recent server changes (From #625 ) didn't bump the server version making it more difficult to determine deployed versions. This PR just bumps the version in fission-web-server/package.yaml.