### PR TITLE
kubo rename and bump cli to 0.17

### DIFF
--- a/fission-cli/library/Fission/CLI/IPFS/Download/GitHub/Types.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Download/GitHub/Types.hs
@@ -9,7 +9,7 @@ import qualified Fission.CLI.IPFS.Version.Types as IPFS
 
 type GetRelease
   = "ipfs"
-  :> "go-ipfs"
+  :> "kubo"
   :> "releases"
   :> "download"
   :> Capture "version" IPFS.Version

--- a/fission-cli/library/Fission/CLI/IPFS/Executable.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Executable.hs
@@ -71,7 +71,7 @@ place' host = do
   IPFS.BinPath ipfsPath <- Path.globalIPFSBin
 
   -- Network
-  ipfsBin <- ensureM . unpack =<< download (IPFS.Version 0 12 2) host
+  ipfsBin <- ensureM . unpack =<< download (IPFS.Version 0 17 0) host
 
   logDebug @Text "🚎 Moving IPFS into place..."
   File.lazyForceWrite ipfsPath ipfsBin
@@ -89,7 +89,7 @@ download ::
   -> OS.Supported
   -> m Lazy.ByteString
 download version os = do
-  logDebug $ "⬇️  Downloading go-ipfs " <> display version <> " for " <> display os
+  logDebug $ "⬇️  Downloading kubo " <> display version <> " for " <> display os
   ensureM . GitHub.sendRequest $ IPFS.getRelease IPFS.Release {..}
 
 unpack :: (MonadIO m, MonadLogger m) => Lazy.ByteString -> m (Either (NotFound FilePath) Lazy.ByteString)
@@ -104,7 +104,7 @@ unpack tarGz = do
     getIPFS :: Tar.Entry -> Either (NotFound FilePath) Lazy.ByteString -> Either (NotFound FilePath) Lazy.ByteString
     getIPFS entry acc =
       case (Tar.entryPath entry, Tar.entryContent entry) of
-        ("go-ipfs/ipfs", Tar.NormalFile ipfsBin _) -> Right ipfsBin
+        ("kubo/ipfs", Tar.NormalFile ipfsBin _) -> Right ipfsBin
         _                                          -> acc
 
 configure ::

--- a/fission-cli/library/Fission/CLI/IPFS/Release/Types.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Release/Types.hs
@@ -17,7 +17,7 @@ data Release = Release
 instance Display Release where
   display Release {..} =
     mconcat
-      [ "go-ipfs_"
+      [ "kubo_"
       , display version
       , "_"
       , osLabel

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: "2.19.0.0"
+version: "2.20.0.0"
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Title says it all, bumping the bundled kubo version from 0.12 to 0.17 (which includes the s/go-ipfs/kubo/ rename)